### PR TITLE
control tolerance in RA preconditioner

### DIFF
--- a/src/haznics/haznics.i
+++ b/src/haznics/haznics.i
@@ -224,7 +224,7 @@ precond* create_precond_amg(dCSRmat *A, AMG_param *amgparam);
 precond* set_precond(void *data, void (*foo)(REAL*, REAL*, void*));
 precond* create_precond(dCSRmat *A, AMG_param *amgparam);
 precond* create_precond_famg(dCSRmat *A, dCSRmat *M, AMG_param *amgparam);
-precond* create_precond_ra(dCSRmat *A, dCSRmat *M, REAL s_frac_power, REAL t_frac_power, REAL alpha, REAL beta, REAL scaling_a, REAL scaling_m, AMG_param *amgparam);
+precond* create_precond_ra(dCSRmat *A, dCSRmat *M, REAL s_frac_power, REAL t_frac_power, REAL alpha, REAL beta, REAL scaling_a, REAL scaling_m, REAL ra_tol, AMG_param *amgparam);
 precond* create_precond_hxcurl(dCSRmat *Acurl, dCSRmat *Pcurl, dCSRmat *Grad, SHORT prectype, AMG_param *amgparam);
 precond* create_precond_hxdiv_3D(dCSRmat *Adiv, dCSRmat *P_div, dCSRmat *Curl, dCSRmat *P_curl, SHORT prectype, AMG_param *amgparam);
 precond* create_precond_hxdiv_2D(dCSRmat *Adiv,dCSRmat *P_div, dCSRmat *Curl, SHORT prectype, AMG_param *amgparam);

--- a/src/haznics/helper.c
+++ b/src/haznics/helper.c
@@ -433,6 +433,7 @@ precond* create_precond_ra(dCSRmat *A,
                            REAL beta,
                            REAL scaling_a,
                            REAL scaling_m,
+			   REAL ra_tol,
                            AMG_param *amgparam)
 {
     precond *pc = (precond*)calloc(1, sizeof(precond));
@@ -482,7 +483,7 @@ precond* create_precond_ra(dCSRmat *A,
     /* AAA algorithm for the rational approximation */
     // parameters used in the AAA algorithm
     INT mmax_in = 50;  // maximal final number of pole + 1
-    REAL16 AAA_tol = powl(2e0,-40e0);  // tolerance of the AAA algorithm
+    REAL16 AAA_tol = fmax(ra_tol, powl(2e0,-40e0));  // tolerance of the AAA algorithm
     INT k = -22; // k is the number of nodes in the final interpolation after tolerance is achieved or mmax is reached.
     INT print_level = 0; // print level for AAA
     // output of the AAA algorithm.  It contains residues (Re + Im), poles (Re + Im), nodes, weights, function values


### PR DESCRIPTION
This PR modifies signature of `create_precond_ra` such that we pass the tolerance for `AAA`. 